### PR TITLE
Add ws dependency to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "dependencies": {
         "ejs": "^4.0.1",
         "express": "^5.2.1",
-        "ws": "^8.19.0"
+        
     },
     "type": "module",
     "scripts": {
@@ -11,6 +11,7 @@
         "start": "node server.js"
     },
     "devDependencies": {
-        "nodemon": "^3.1.11"
+        "nodemon": "^3.1.11",
+        "ws": "^8.19.0"  
     }
 }


### PR DESCRIPTION
Added ws to devDependencies since it’s used only in development (tooling/tests). This keeps production installs lighter and reduces unnecessary packages in runtime.